### PR TITLE
 - Altered SwagOMeterViewModel.cs and SwagOMeterAwardEngine.cs to defaul...

### DIFF
--- a/Swagometer/Objects/SwagOMeterAwardEngine.cs
+++ b/Swagometer/Objects/SwagOMeterAwardEngine.cs
@@ -60,8 +60,13 @@ namespace Swagometer.ViewModels
 
         public SwagOMeterAwardEngine(IAttendeeSource attendeeSource, ISwagSource swagSource)
         {
-            _attendees = attendeeSource.Load(Properties.Settings.Default.FileLocation);
-            _swag = swagSource.Load(Properties.Settings.Default.FileLocation);
+            string FileLocation = Properties.Settings.Default.FileLocation;
+            if (FileLocation == String.Empty)
+            {
+                FileLocation = new System.IO.FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).DirectoryName;
+            }
+            _attendees = attendeeSource.Load(FileLocation);
+            _swag = swagSource.Load(FileLocation);
 
             CheckCanSwag();
         }

--- a/Swagometer/ViewModels/SwagOMeterViewModel.cs
+++ b/Swagometer/ViewModels/SwagOMeterViewModel.cs
@@ -157,8 +157,13 @@ namespace Swagometer.ViewModels
 
         public void ViewReady()
         {
-            _attendees = _attendeeSource.Load(Properties.Settings.Default.FileLocation);
-            _swag = _swagSource.Load(Properties.Settings.Default.FileLocation);
+            string FileLocation = Properties.Settings.Default.FileLocation;
+            if (FileLocation == String.Empty )
+            {
+                FileLocation = new System.IO.FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).DirectoryName;
+            }
+            _attendees = _attendeeSource.Load(FileLocation);
+            _swag = _swagSource.Load(FileLocation);
 
             CheckCanSwag();
         }


### PR DESCRIPTION
...t loading files from where the exe is.

These changes will cause the app to look in the executing essembly's folder for both swag.xml and attendees.xml if their location is not explicitly defined.
